### PR TITLE
Return application/json+error for errors when asking for application/json

### DIFF
--- a/apio-architect-impl/src/main/java/com/liferay/apio/architect/internal/message/json/problem/ProblemJSONErrorMessageMapper.java
+++ b/apio-architect-impl/src/main/java/com/liferay/apio/architect/internal/message/json/problem/ProblemJSONErrorMessageMapper.java
@@ -32,7 +32,7 @@ public class ProblemJSONErrorMessageMapper implements ErrorMessageMapper {
 
 	@Override
 	public String getMediaType() {
-		return "application/problem+json";
+		return "application/json";
 	}
 
 	@Override


### PR DESCRIPTION
Right now, when something fails with application/json the response doesn't contain any information

I know it is not "spec correct" because it doesn't return `application/json` but you need to request `Accept: application/problem+json` if you want to receive the detailed response